### PR TITLE
Evita o erro Invalid specifier: '!=3.4.*!=3.5.*'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*!=3.5.*",
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*",
     install_requires=[
         "setuptools",
         "plone.app.registry",


### PR DESCRIPTION
acrescenta virgula em python_requires para evitar o erro Invalid specifier: '!=3.4.*!=3.5.*

 error in collective.js.galleria setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '!=3.4.*!=3.5.*'